### PR TITLE
add lark chat_id support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,10 @@
 # Unignore all dirs
 !*/
 !api
-
+.vscode
 .idea
 pro.yaml
+config.yaml
 **/.DS_Store
 **/logs
 

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -6,6 +6,8 @@ lark:
   appSecret: <app secret>
   receiver: <receiver's lark UserID>
   receiver_email: <receiver's lark Email>
+lark_webhook:
+  url: <the webhook url for the robot>
 slack:
   token: <oauth token>
   channel: <channel>

--- a/lark/agent.go
+++ b/lark/agent.go
@@ -9,9 +9,10 @@ import (
 
 const messageType = "text"
 
-var App *feishu.App
-
 type (
+	App struct {
+		app *feishu.App
+	}
 	content struct {
 		Text string `json:"text"`
 	}
@@ -24,11 +25,16 @@ type (
 	}
 )
 
-func Send(app, secret, receiver, receiverEmail, text string) error {
-	App = feishu.NewApp(feishu.AppConfig{
-		AppId:     app,
-		AppSecret: secret,
-	})
+func NewApp(appid, secret string) *App {
+	return &App{
+		app: feishu.NewApp(feishu.AppConfig{
+			AppId:     appid,
+			AppSecret: secret,
+		}),
+	}
+}
+
+func (app *App) Send(receiver, receiverEmail, text string) error {
 	payload, err := json.Marshal(Message{
 		UserId:  receiver,
 		Email:   receiverEmail,
@@ -40,7 +46,6 @@ func Send(app, secret, receiver, receiverEmail, text string) error {
 	if err != nil {
 		return err
 	}
-
-	_, err = message.Send(App, payload)
+	_, err = message.Send(app.app, payload)
 	return err
 }

--- a/lark_webhook/agent.go
+++ b/lark_webhook/agent.go
@@ -45,7 +45,6 @@ func Send(url, message string) error {
 		return err
 	}
 
-	logx.Info("rsp is:", rsp)
 	if rsp.StatusCode != 0 {
 		return errors.New(rsp.StatusMessage)
 	}

--- a/lark_webhook/agent.go
+++ b/lark_webhook/agent.go
@@ -1,0 +1,55 @@
+package lark_webhook
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/tal-tech/go-zero/core/jsonx"
+	"github.com/tal-tech/go-zero/core/logx"
+)
+
+type (
+	Response struct {
+		StatusCode    int    `json:"StatusCode"`
+		StatusMessage string `json:"StatusMessage"`
+	}
+)
+
+func Send(url, message string) error {
+	slackMsg := map[string]interface{}{
+		"msg_type": "text",
+		"content": map[string]interface{}{
+			"text": message,
+		},
+	}
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	if err := encoder.Encode(slackMsg); err != nil {
+		return err
+	}
+
+	r, err := http.NewRequest(http.MethodPost, url, &buf)
+	if err != nil {
+		return err
+	}
+
+	resp, err := new(http.Client).Do(r)
+	if err != nil {
+		return err
+	}
+
+	var rsp Response
+	if err := jsonx.UnmarshalFromReader(resp.Body, &rsp); err != nil {
+		return err
+	}
+
+	logx.Info("rsp is:", rsp)
+	if rsp.StatusCode != 0 {
+		return errors.New(rsp.StatusMessage)
+	}
+
+	logx.Info("sent")
+	return nil
+}

--- a/lark_webhook/config.go
+++ b/lark_webhook/config.go
@@ -1,0 +1,5 @@
+package lark_webhook
+
+type LarkWebhook struct {
+	Url string `json:"url"`
+}


### PR DESCRIPTION
I want to send the star notification to lark chat, where my partner can easily get in/out.

I introduce a breaking change: 
usage:
    stargazers <command>

The commands are:
    list_lark_chat:   list the lark chats including the robot to find the chat_id.
    monitor:          monitor the repo stargazers.
